### PR TITLE
:bug: Fix NA value handling in stats page

### DIFF
--- a/stats.qmd
+++ b/stats.qmd
@@ -20,17 +20,18 @@ processed <-
   readRDS("data/processed_paddles.rds") |>
    sf::st_drop_geometry()
 
-monthly_totals <- 
+monthly_totals <-
   processed |>
   dplyr::mutate(year_month = lubridate::floor_date(start_date, "month")) |>
   dplyr::group_by(year_month) |>
-  dplyr::summarise(distance = sum(distance), .groups = "drop") |>
+  dplyr::summarise(distance = sum(distance, na.rm = TRUE), .groups = "drop") |>
   tidyr::complete(
     year_month = seq(min(year_month), max(year_month), by = "1 month"),
     fill = list(distance = 0)
     )
 
 longest_paddles <- processed |>
+  dplyr::filter(!is.na(distance)) |>
   dplyr::slice_max(distance, n = 10) |>
   dplyr::select(name, start_date, distance, filename)
 ```
@@ -39,7 +40,10 @@ longest_paddles <- processed |>
 ## At a glance
 
 ```{r}
-longest <- processed |> dplyr::slice_max(distance) |> dplyr::select(name, filename, distance)
+longest <- processed |>
+  dplyr::filter(!is.na(distance)) |>
+  dplyr::slice_max(distance, n = 1) |>
+  dplyr::select(name, filename, distance)
 ```
 
 ```{r}
@@ -54,13 +58,13 @@ bslib::layout_columns(
   ),
   bslib::value_box(
     title = "Distance paddled",
-    value = glue::glue("{round(sum(processed$distance))} km"),
+    value = glue::glue("{round(sum(processed$distance, na.rm = TRUE))} km"),
     showcase = bsicons::bs_icon("pin-map-fill"),
     theme = "primary"
   ),
   bslib::value_box(
     title = "Time on the water",
-    value = glue::glue("{round(sum(processed$moving_time_minutes) / 60)} hours"),
+    value = glue::glue("{round(sum(processed$moving_time_minutes, na.rm = TRUE) / 60)} hours"),
     showcase = bsicons::bs_icon("clock-fill"),
     theme = "primary"
   ),
@@ -88,7 +92,7 @@ bslib::layout_columns(
 year_count <- processed |>
   dplyr::mutate(year = lubridate::year(start_date)) |>
   dplyr::group_by(year) |>
-  dplyr::summarise(total_km = sum(distance),
+  dplyr::summarise(total_km = sum(distance, na.rm = TRUE),
                    count = n()) |>
   tidyr::pivot_longer(
     cols = c(total_km, count),


### PR DESCRIPTION
## Summary

Fixes issue #37 - NA values in distance and moving_time_minutes columns are now properly handled:

- Added `na.rm = TRUE` to all `sum()` calls for distance and moving_time_minutes
- Filter NA values before using `slice_max()` to get longest paddle  
- Prevents n/a results in summary statistics and charts
- Fixes table sorting issues caused by NA values in distance column

## Changes

- `stats.qmd`: Added NA handling to value boxes, year-by-year chart, and longest paddles table

## Testing

These changes will now:
- Calculate correct totals for distance and time even when some activities have NA values
- Display correct "Longest Paddle" value box
- Allow the top 10 longest paddles table to sort properly
- Show accurate year-by-year statistics

🧊 Generated with [Claude Code](https://claude.com/claude-code)